### PR TITLE
Use 30 second refreshes on non-initial load indexing jobs

### DIFF
--- a/eevee/indexing/indexers.py
+++ b/eevee/indexing/indexers.py
@@ -377,7 +377,7 @@ class IndexingTask:
             else:
                 # extend the refresh during updates, the default is 1 second so extending to 30
                 # seconds should improve performance a bit
-                update_refresh_interval(self.elasticsearch, [self.index], 30)
+                update_refresh_interval(self.elasticsearch, [self.index], u'30s')
 
             # we can ignore the success value as if there is a problem streaming_bulk will raise an
             # exception

--- a/eevee/indexing/indexers.py
+++ b/eevee/indexing/indexers.py
@@ -366,10 +366,18 @@ class IndexingTask:
         """
         Indexes a set of records from mongo into elasticsearch.
         """
+        is_clean = self.is_clean_index()
         try:
-            # use some optimisations for loading data
-            update_refresh_interval(self.elasticsearch, [self.index], -1)
-            update_number_of_replicas(self.elasticsearch, [self.index], 0)
+            # for info on the refresh and replica settings changed here, see:
+            # https://www.elastic.co/guide/en/elasticsearch/reference/master/tune-for-indexing-speed.html
+            if is_clean:
+                # use some optimisations for loading initial data
+                update_refresh_interval(self.elasticsearch, [self.index], -1)
+                update_number_of_replicas(self.elasticsearch, [self.index], 0)
+            else:
+                # extend the refresh during updates, the default is 1 second so extending to 30
+                # seconds should improve performance a bit
+                update_refresh_interval(self.elasticsearch, [self.index], 30)
 
             # we can ignore the success value as if there is a problem streaming_bulk will raise an
             # exception

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
-mock==2.0.0
-pytest==3.6.2
-pytest-cov==2.5.1
-tox==3.0.0
+mock==3.0.5
+pytest==4.6.5
+pytest-cov==2.7.1
+tox==3.14.0


### PR DESCRIPTION
If the indexing we're doing is the first time load of the index then it's worth doing the refresh: -1. replicas: 0 thing. If not, and we're just updating the docs in the index, we shouldn't do this, we should only update the refresh. The suggested value in the [tuning documentation](https://www.elastic.co/guide/en/elasticsearch/reference/master/tune-for-indexing-speed.html) is 30s.